### PR TITLE
CFP for Out of stock

### DIFF
--- a/includes/admin/class-wc-call-for-price-settings-general.php
+++ b/includes/admin/class-wc-call-for-price-settings-general.php
@@ -234,20 +234,10 @@ if ( ! class_exists( 'Alg_WC_Call_For_Price_Settings_General' ) ) :
 				array(
 					'title'             => __( '"Out of stock" products', 'woocommerce-call-for-price' ),
 					'desc'              => __( 'Enable', 'woocommerce-call-for-price' ),
-					'desc_tip'          => __( 'Makes "Call for Price" for all products that can not be purchased (not "in stock" or "on backorder" stock statuses).', 'woocommerce-call-for-price' ) .
-					apply_filters(
-						'alg_call_for_price',
-						'<br>' . sprintf( /* translators: %s: Link to pro version */
-							__( 'You will need %s plugin to enable this option.', 'woocommerce-call-for-price' ),
-							'<a target="_blank" href="https://www.tychesoftwares.com/store/premium-plugins/woocommerce-call-for-price-plugin/?utm_source=cfpupgradetopro&utm_medium=link&utm_campaign=CallForPriceLite">' .
-							__( 'Call for Price for WooCommerce Pro', 'woocommerce-call-for-price' ) . '</a>'
-						),
-						'settings'
-					),
+					'desc_tip'          => __( 'Makes "Call for Price" for all products that can not be purchased (not "in stock" or "on backorder" stock statuses).', 'woocommerce-call-for-price' ),
 					'id'                => 'alg_call_for_price_make_out_of_stock_empty_price',
 					'default'           => 'no',
 					'type'              => 'checkbox',
-					'custom_attributes' => apply_filters( 'alg_call_for_price', array( 'disabled' => 'disabled' ), 'settings' ),
 				),
 				array(
 					'title'    => __( 'Per product taxonomy', 'woocommerce-call-for-price' ),

--- a/includes/class-wc-call-for-price.php
+++ b/includes/class-wc-call-for-price.php
@@ -62,7 +62,8 @@ if ( ! class_exists( 'Alg_WC_Call_For_Price' ) ) :
 					$this->hook_price_filters( 'make_empty_price' );
 				}
 				// Out of stock products.
-				if ( 'yes' === apply_filters( 'alg_call_for_price', 'no', 'out_of_stock' ) ) {
+
+				if ( 'yes' === get_option( 'alg_call_for_price_make_out_of_stock_empty_price', 'no' ) ) {
 					$this->hook_price_filters( 'make_empty_price_out_of_stock' );
 				}
 				// "Call for Price" per product taxonomy.

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ Supported views:
 You can also optionally force "Call for Price" for:
 
 * All your shop's products
-* "Out of stock" products (Pro version only)
+* "Out of stock" products
 * Per product taxonomy (categories and/or tags)
 * By product's price
 


### PR DESCRIPTION
In this commit, I have added an option called Out of stock product, enabling this option will apply the call for price settings to the products that are out of stock.

BRD: https://docs.google.com/document/d/1E19D7IFpAUVRl8jEei55m4sxj-056O-9P1C_TCKlAnU/edit?tab=t.0

