### PR TITLE
Fix #81 Fix security issue.

### DIFF
--- a/includes/admin/class-wc-call-for-price-settings-product-types.php
+++ b/includes/admin/class-wc-call-for-price-settings-product-types.php
@@ -66,7 +66,10 @@ if ( ! class_exists( 'Alg_WC_Call_For_Price_Settings_Product_Types' ) ) :
 		 * @since   3.1.0
 		 */
 		public function unclean_custom_textarea( $value, $option, $raw_value ) {
-			return ( 'alg_wc_call_for_price_textarea' === $option['type'] ) ? $raw_value : $value;
+			if ( 'alg_wc_call_for_price_textarea' === $option['type'] ) {
+				return wp_kses_post( $raw_value );
+			}
+			return $value;
 		}
 
 		/**

--- a/includes/class-wc-call-for-price.php
+++ b/includes/class-wc-call-for-price.php
@@ -235,7 +235,7 @@ if ( ! class_exists( 'Alg_WC_Call_For_Price' ) ) :
 					if ( true === $status ) {
 						return $price_html;
 					} else {
-						return do_shortcode( $label );
+						return wp_kses_post( do_shortcode( $label ) );
 					}
 				}
 			}
@@ -678,7 +678,7 @@ if ( ! class_exists( 'Alg_WC_Call_For_Price' ) ) :
 					array( 'product_id' => $_product_id )
 				);
 			}
-			return do_shortcode( $label );
+			return wp_kses_post( do_shortcode( $label ) );
 		}
 	}
 


### PR DESCRIPTION
Fix #81 Fix security issue.Fix the security issue.

Cause: The plugin bypassed WooCommerce sanitization by returning raw $raw_value for the custom textarea and outputted it without escaping, allowing stored XSS.

Fix: Applied wp_kses_post() to sanitize the input before saving and escape the output (wp_kses_post( do_shortcode( $label ) )) to allow safe HTML while blocking scripts.


**ISSUE** - 
Description
The Call for Price for WooCommerce plugin for WordPress is vulnerable to Stored Cross-Site Scripting via admin settings in all versions up to, and including, 4.2.0 due to insufficient input sanitization and output escaping. This makes it possible for authenticated attackers, with administrator-level permissions and above, to inject arbitrary web scripts in pages that will execute whenever a user accesses an injected page. This only affects multi-site installations and installations where unfiltered_html has been disabled.

Proof of Concept
<!-- DISCLAIMER: This script is provided solely for authorized security testing on systems you own or have explicit written permission to test. Its purpose is to validate a vulnerability so the issue can be responsibly patched. Unauthorized use against systems you do not own or have permission to test is illegal and unethical. -->

Step 1: Login. Log in to WordPress as an Administrator or Shop Manager.

Step 2: Navigate to Settings. Go to WooCommerce > Settings > Call for Price > Product Types > Simple Products (or any other product type tab).

Step 3: Inject Payload. In the 'Single product page' textarea (field id: alg_wc_call_for_price_text_simple_single), enter the following XSS payload:
"><script>alert(document.cookie)</script>

Note: In the free version, only the 'Single product page' text field is editable; other view fields are readonly.

Step 4: Save Settings. Click 'Save changes'. The payload is saved in the database without sanitization because the unclean_custom_textarea() function returns the raw $raw_value bypassing WooCommerce's sanitize pipeline.

Step 5: Trigger XSS. Visit any product page on the frontend where the product has no price set (empty price) and the 'Call for Price' feature is enabled. The JavaScript will execute immediately.

Step 6: Verify. You will see the alert box confirming Stored XSS.

Any Known Public References
https://plugins.trac.wordpress.org/browser/woocommerce-call-for-price/trunk/includes/admin/class-wc-call-for-price-settings-product-types.php#L68
https://plugins.trac.wordpress.org/browser/woocommerce-call-for-price/trunk/includes/class-wc-call-for-price.php#L681
https://plugins.trac.wordpress.org/browser/woocommerce-call-for-price/tags/4.2.0/includes/class-wc-call-for-price.php#L681
https://plugins.trac.wordpress.org/browser/woocommerce-call-for-price/tags/4.2.0/includes/admin/class-wc-call-for-price-settings-product-types.php#L68

Recommended Solution
Remove the unclean_custom_textarea() filter hook, or replace it with a function that applies proper sanitization (e.g., wp_kses_post() to allow basic HTML but strip JavaScript) rather than returning $raw_value. Additionally, apply esc_html() or wp_kses_post() at the output in on_empty_price() before returning $label.
